### PR TITLE
Set version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 ## Deploy
 
+if you're not using `tfenv`, see [USE_TFENV.md](/USE_TFENV.md)
+
 ```bash
+tfenv install min-required
+tfenv use min-required
+
 cp <SOMEWHERE> dbgen/ids.json # Add ids.json
 
 cp terraform.tfvars{.sample,}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Deploy
 
-if you're not using `tfenv`, see [USE_TFENV.md](/USE_TFENV.md)
+if you're not using `tfenv`, see [USE_TFENV.md](/USE_TFENV.md) first
 
 ```bash
 tfenv install min-required

--- a/USE_TFENV.md
+++ b/USE_TFENV.md
@@ -1,0 +1,19 @@
+# Use `tfenv`
+
+This repository requires [tfenv](https://github.com/tfutils/tfenv) to be installed on your system.
+
+See the following instructions to install `tfenv`:
+
+## 1. Delete existing `terraform` installation
+
+```bash
+# rm "$(which terraform)"
+```
+
+## 2. Install `tfenv`
+
+```bash
+$ brew install tfenv
+```
+
+for manual installation, see [tfutils/tfenv](https://github.com/tfutils/tfenv)

--- a/USE_TFENV.md
+++ b/USE_TFENV.md
@@ -7,7 +7,7 @@ See the following instructions to install `tfenv`:
 ## 1. Delete existing `terraform` installation
 
 ```bash
-# this operation may requires root privilege
+# this operation may require root privilege
 sudo rm "$(which terraform)"
 ```
 
@@ -17,4 +17,4 @@ sudo rm "$(which terraform)"
 brew install tfenv
 ```
 
-for manual installation, see [tfutils/tfenv](https://github.com/tfutils/tfenv)
+for the manual installation, see [tfutils/tfenv](https://github.com/tfutils/tfenv)

--- a/USE_TFENV.md
+++ b/USE_TFENV.md
@@ -7,13 +7,14 @@ See the following instructions to install `tfenv`:
 ## 1. Delete existing `terraform` installation
 
 ```bash
-# rm "$(which terraform)"
+# this operation may requires root privilege
+sudo rm "$(which terraform)"
 ```
 
 ## 2. Install `tfenv`
 
 ```bash
-$ brew install tfenv
+brew install tfenv
 ```
 
 for manual installation, see [tfutils/tfenv](https://github.com/tfutils/tfenv)

--- a/cert.tf
+++ b/cert.tf
@@ -1,7 +1,3 @@
-provider "acme" {
-  server_url = "${var.acme_server_url}"
-}
-
 resource "tls_private_key" "private_key" {
   algorithm = "RSA"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -7,6 +7,8 @@ provider "aws" {
 }
 
 provider "acme" {
+  server_url = "${var.acme_server_url}"
+
   version = "~> 1.2.0"
 }
 

--- a/provider.tf
+++ b/provider.tf
@@ -2,4 +2,22 @@ provider "aws" {
   region = "${var.aws_region}"
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"
+
+  version = "~> 2.7.0"
+}
+
+provider "acme" {
+  version = "~> 1.2.0"
+}
+
+provider "archive" {
+  version = "~> 1.2.0"
+}
+
+provider "template" {
+  version = "~> 2.1.0"
+}
+
+provider "tls" {
+  version = "~> 2.0.0"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -3,13 +3,13 @@ provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"
 
-  version = "~> 2.7.0"
+  version = "~> 2.6.0"
 }
 
 provider "acme" {
   server_url = "${var.acme_server_url}"
 
-  version = "~> 1.2.0"
+  version = "~> 1.1.0"
 }
 
 provider "archive" {
@@ -21,5 +21,5 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 2.0.0"
+  version = "~> 1.2.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "0.11.14"
+}


### PR DESCRIPTION
Set version constraints of providers and terraform itself.

- Fix #15 
- Specify required versions in `provider.tf`
- Specify the required version in `versions.tf`
- Add instructions to use `tfenv`

with this change, versions should be like this below

```
Terraform v0.11.14
+ provider.acme v1.1.2
+ provider.archive v1.2.2
+ provider.aws v2.6.0
+ provider.template v2.1.2
+ provider.tls v1.2.0
```