### PR TITLE
Fix "Unzipped size must be smaller than 262144000 bytes" error in deployment

### DIFF
--- a/dbgen/Makefile
+++ b/dbgen/Makefile
@@ -5,7 +5,8 @@ ${DELIVERABLE}: $(wildcard ./*.py) ids.json install-deps
 	-rm ${DELIVERABLE}
 	zip -qr9 ${DELIVERABLE} ./
 	$(eval VENV = $(shell pipenv --venv))
-	cd ${VENV}/lib/python3.6/site-packages && zip -qr9 ${DELIVERABLE} ./
+	cd ${VENV}/lib/python3.6/site-packages
+	find . -type f -not -name '*.pyc' -print | zip -q9@ ${DELIVERABLE}
 
 .PHONY: install-deps
 install-deps: Pipfile Pipfile.lock

--- a/dbgen/Makefile
+++ b/dbgen/Makefile
@@ -3,7 +3,7 @@ DELIVERABLE=${abspath ${FILE}}
 
 ${DELIVERABLE}: $(wildcard ./*.py) ids.json install-deps
 	-rm ${DELIVERABLE}
-	zip -qr9 ${DELIVERABLE} ./
+	find . -type d -name '.venv' -prune -o -type f -print | zip -q9@ ${DELIVERABLE}
 	$(eval VENV = $(shell pipenv --venv))
 	cd ${VENV}/lib/python3.6/site-packages && find . -type f -not -name '*.pyc' -print | zip -q9@ ${DELIVERABLE}
 

--- a/dbgen/Makefile
+++ b/dbgen/Makefile
@@ -5,10 +5,8 @@ ${DELIVERABLE}: $(wildcard ./*.py) ids.json install-deps
 	-rm ${DELIVERABLE}
 	zip -qr9 ${DELIVERABLE} ./
 	$(eval VENV = $(shell pipenv --venv))
-	cd ${VENV}/lib/python3.6/site-packages
-	find . -type f -not -name '*.pyc' -print | zip -q9@ ${DELIVERABLE}
+	cd ${VENV}/lib/python3.6/site-packages && find . -type f -not -name '*.pyc' -print | zip -q9@ ${DELIVERABLE}
 
 .PHONY: install-deps
 install-deps: Pipfile Pipfile.lock
 	pipenv install
-


### PR DESCRIPTION
pythonのキャッシュファイルを含めないzipを作るようにしてサイズを削減しました

一部環境で`$VENV`が`dbgen/`にできた結果二重にsite-packagesをzipに追加してしまうことがあったので修正しました

- Exclude .pyc from the archive
- Exclude .venv/* from the archive

## 影響

少し実行が遅くなるかもしれないが困らない